### PR TITLE
Extension icon is displayed in Visual Studio | Extensions.

### DIFF
--- a/src/Code/FeedWriter.cs
+++ b/src/Code/FeedWriter.cs
@@ -75,7 +75,7 @@ namespace VsixGallery
 
             writer.WriteStartElement("link");
             writer.WriteAttributeString("rel", "icon");
-            writer.WriteAttributeString("href", baseUrl + "/extensions/" + package.ID + "/" + package.Icon);
+            writer.WriteAttributeString("href", baseUrl + package.Icon);
             writer.WriteEndElement(); // icon
 
             writer.WriteRaw("\r\n<Vsix xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"http://schemas.microsoft.com/developer/vsx-syndication-schema/2010\">\r\n");


### PR DESCRIPTION
The feed contains a link to the extension icon.
This link should not contain the folder
extensions/{package.id} twice.

With this fix, the extension icon should appear in
Visual Studio | Extensions | Open VSIX Gallery | Extension Details.