### PR TITLE
Corrected spelling on Search.cshtml

### DIFF
--- a/src/Pages/Search.cshtml
+++ b/src/Pages/Search.cshtml
@@ -5,6 +5,6 @@
     ViewData["Title"] = "Search results for '@Model.Term'";
 }
 
-<h1>@Model.Packages.Count() resuls for <em>@Model.Term</em></h1>
+<h1>@Model.Packages.Count() results for <em>@Model.Term</em></h1>
 
 @await Html.PartialAsync("_ExtensionList", Model.Packages)


### PR DESCRIPTION
Corrected 'resuls' to 'results'