### PR TITLE
Added query parameter to specify path to the readme URL.

### DIFF
--- a/src/Code/Package.cs
+++ b/src/Code/Package.cs
@@ -23,6 +23,7 @@ namespace VsixGallery
 		public string MoreInfoUrl { get; set; }
 		public string Repo { get; set; }
 		public string IssueTracker { get; set; }
+		public string ReadmeUrl { get; set; }
 		public ExtensionList ExtensionList { get; set; }
 
 		[JsonIgnore]

--- a/src/Code/PackageHelper.cs
+++ b/src/Code/PackageHelper.cs
@@ -145,7 +145,7 @@ namespace VsixGallery
 			return JsonConvert.DeserializeObject(content, typeof(Package)) as Package;
 		}
 
-		public async Task<Package> ProcessVsix(IFormFile file, string repo, string issuetracker)
+		public async Task<Package> ProcessVsix(IFormFile file, string repo, string issuetracker, string readmeUrl)
 		{
 			string tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
@@ -166,7 +166,7 @@ namespace VsixGallery
 				ZipFile.ExtractToDirectory(tempVsix, tempFolder);
 
 				VsixManifestParser parser = new VsixManifestParser();
-				Package package = parser.CreateFromManifest(tempFolder, repo, issuetracker);
+				Package package = parser.CreateFromManifest(tempFolder, repo, issuetracker, readmeUrl);
 
 				string vsixFolder = Path.Combine(_extensionRoot, package.ID);
 

--- a/src/Code/VsixManifestParser.cs
+++ b/src/Code/VsixManifestParser.cs
@@ -11,7 +11,7 @@ namespace VsixGallery
 {
 	public class VsixManifestParser
 	{
-		public Package CreateFromManifest(string tempFolder, string repo, string issuetracker)
+		public Package CreateFromManifest(string tempFolder, string repo, string issuetracker, string readmeUrl)
 		{
 			string xml = File.ReadAllText(Path.Combine(tempFolder, "extension.vsixmanifest"));
 			xml = Regex.Replace(xml, "( xmlns(:\\w+)?)=\"([^\"]+)\"", string.Empty);
@@ -22,7 +22,8 @@ namespace VsixGallery
 			Package package = new Package
 			{
 				Repo = repo,
-				IssueTracker = issuetracker
+				IssueTracker = issuetracker,
+				ReadmeUrl = BuildReadmeUrl(repo, readmeUrl)
 			};
 
 			if (doc.GetElementsByTagName("DisplayName").Count > 0)
@@ -47,6 +48,26 @@ namespace VsixGallery
 			AddExtensionList(package, tempFolder);
 
 			return package;
+		}
+
+		private string BuildReadmeUrl(string repo, string readmeUrl)
+		{
+			// Default to `master/README.md` if a URL was not specified.
+			if (string.IsNullOrWhiteSpace(readmeUrl))
+			{
+				readmeUrl = "master/README.md";
+			}
+
+			// If the provided URL is absolute, then use it
+			// as is; otherwise, assume it's a GitHub URL.
+			if (Regex.IsMatch(readmeUrl, "^https?://"))
+			{
+				return readmeUrl;
+			}
+			else
+			{
+				return repo.Replace("https://github.com", "https://raw.githubusercontent.com").TrimEnd('/') + "/" + readmeUrl.TrimStart('/');
+			}
 		}
 
 		private void AddExtensionList(Package package, string tempFolder)

--- a/src/Controllers/ApiController.cs
+++ b/src/Controllers/ApiController.cs
@@ -46,13 +46,13 @@ namespace VsixGallery.Controllers
 		}
 
 		[HttpPost, DisableRequestSizeLimit]
-		public async Task<IActionResult> Upload([FromQuery] string repo, string issuetracker)
+		public async Task<IActionResult> Upload([FromQuery] string repo, string issuetracker, string readmeUrl)
 		{
 			try
 			{
 				HttpContext.Request.EnableBuffering();
 
-				Package package = await _helper.ProcessVsix(Request.Form.Files[0], repo, issuetracker);
+				Package package = await _helper.ProcessVsix(Request.Form.Files[0], repo, issuetracker, readmeUrl);
 
 				return Json(package);
 			}

--- a/src/Pages/Extension.cshtml
+++ b/src/Pages/Extension.cshtml
@@ -58,20 +58,16 @@
         </div>
     }
 
-    @if (!string.IsNullOrWhiteSpace(Model.Package.Repo))
+    @if (!string.IsNullOrWhiteSpace(Model.Package.ReadmeUrl))
     {
         <p id="readme">Loading...</p>
+        <script>
+            var readme = document.getElementById('readme');
+            var url = '@Model.Package.ReadmeUrl';
+
+            fetch('https://markdownservice.azurewebsites.net/markdown.ashx?url=' + url)
+                .then(response => response.text())
+                .then(text => readme.innerHTML = text);
+        </script>
     }
 </article>
-
-@if (!string.IsNullOrWhiteSpace(Model.Package.Repo))
-{
-    <script>
-        var readme = document.getElementById('readme');
-        var url = '@Model.Package.Repo.Replace("https://github.com", "https://raw.githubusercontent.com").TrimEnd('/')' + '/master/README.md';
-
-        fetch('https://markdownservice.azurewebsites.net/markdown.ashx?url=' + url)
-            .then(response => response.text())
-            .then(text => readme.innerHTML = text);
-    </script>
-}


### PR DESCRIPTION
Fixes #10.

The readme URL can be specified in the `readmeUrl` query parameter (it's case-insensitive).

* The readme URL defaults to `master/README.md` on GitHub if it's not specified.
* If a relative URL is specified, then it's assumed to be a GitHub URL and replaces the default `master/README.md`.
* If an absolute URL, then the URL is used as is.