### PR TITLE
Options to hide footer links

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,3 @@
-# Rules in this file were initially inferred by Visual Studio IntelliCode from the D:\Code\GitHub\VsixGallery\src\ codebase based on best match to current usage at 2021-07-21
-# You can modify the rules from these initially generated values to suit your own policies
-# You can learn more about editorconfig here: https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
 [*.cs]
 
 

--- a/src/Options/DisplayOptions.cs
+++ b/src/Options/DisplayOptions.cs
@@ -1,0 +1,13 @@
+﻿namespace VsixGallery
+{
+	public class DisplayOptions
+	{
+		public bool HideSetupLink { get; set; }
+
+		public bool HideUploadGuideLink { get; set; }
+
+		public bool HideCreateExtensionLink { get; set; }
+
+		public bool HideContributeLink { get; set; }
+	}
+}

--- a/src/Pages/Shared/_Layout.cshtml
+++ b/src/Pages/Shared/_Layout.cshtml
@@ -41,22 +41,20 @@
     </main>
 
     <footer>
-        <div class="container">
-            <div>
-                <h3>How to</h3>
-                <ul>
-                    <li><a href="~/feedguide">Set up gallery feed</a></li>
-                    <li><a href="~/devguide">Add your extension</a></li>
-                    <li><a href="https://devblogs.microsoft.com/visualstudio/getting-started-writing-visual-studio-extensions/" rel="noopener noreferrer">Write your first extension</a></li>
-                </ul>
-            </div>
-            <div>
-                <h3>Contribute</h3>
-                <ul>
-                    <li><a href="https://github.com/madskristensen/VsixGallery/" rel="noopener noreferrer">Source code on GitHub</a></li>
-                </ul>
-            </div>
-        </div>
+        <ul>
+            @if (!(bool)ViewData["HideSetupLink"]) {
+                <li><a href="~/feedguide">Set up gallery feed</a></li>
+            }
+            @if (!(bool)ViewData["HideUploadGuideLink"]) {
+                <li><a href="~/devguide">Add your extension</a></li>
+            }
+            @if (!(bool)ViewData["HideCreateExtensionLink"]) {
+                <li><a href="https://devblogs.microsoft.com/visualstudio/getting-started-writing-visual-studio-extensions/" rel="noopener noreferrer">Write your first extension</a></li>
+            }
+            @if (!(bool)ViewData["HideContributeLink"]) {
+                <li><a href="https://github.com/madskristensen/VsixGallery/" rel="noopener noreferrer">Contribute on GitHub</a></li>
+            }
+        </ul>
 
         <p id="copyright">
             Copyright &copy; 2020 <a href="https://www.madskristensen.net" rel="noopener noreferrer">Mads Kristensen</a>

--- a/src/Pages/_ViewStart.cshtml
+++ b/src/Pages/_ViewStart.cshtml
@@ -1,4 +1,6 @@
-﻿@{
+﻿@using Microsoft.Extensions.DependencyInjection;
+@using Microsoft.Extensions.Options;
+@{
     Layout = "_Layout";
 
     Context.Response.Headers["Cache-Control"] = "max-age=180"; // 3 minutes
@@ -10,4 +12,10 @@
         Context.Response.Headers["Referrer-Policy"] = "no-referrer-when-downgrade";
         Context.Response.Headers["X-Frame-Options"] = "DENY";
     }
+
+    DisplayOptions options = Context.RequestServices.GetRequiredService<IOptions<DisplayOptions>>().Value;
+    ViewData["HideSetupLink"] = options.HideSetupLink;
+    ViewData["HideUploadGuideLink"] = options.HideUploadGuideLink;
+    ViewData["HideCreateExtensionLink"] = options.HideCreateExtensionLink;
+    ViewData["HideContributeLink"] = options.HideContributeLink;
 }

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -47,6 +47,7 @@ namespace VsixGallery
 			services.AddSingleton<PackageHelper>();
 
 			services.Configure<ExtensionsOptions>(Configuration.GetSection("Extensions"));
+			services.Configure<DisplayOptions>(Configuration.GetSection("Display"));
 
 			// HTML minification (https://github.com/Taritsyn/WebMarkupMin)
 			services

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -26,7 +26,12 @@ namespace VsixGallery
 		// This method gets called by the runtime. Use this method to add services to the container.
 		public void ConfigureServices(IServiceCollection services)
 		{
-			services.AddRazorPages();
+			IMvcBuilder mvcBuilder = services.AddRazorPages();
+#if DEBUG
+			// The runtime compilation package is only installed for the Debug configuration.
+			mvcBuilder.AddRazorRuntimeCompilation();
+#endif
+
 			services.AddMvc(options => options.EnableEndpointRouting = false);
 			services.AddHsts(options =>
 			{

--- a/src/VsixGallery.csproj
+++ b/src/VsixGallery.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/src/VsixGallery.csproj
+++ b/src/VsixGallery.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -18,6 +18,10 @@
     <PackageReference Include="WebEssentials.AspNetCore.OutputCaching" Version="1.0.28" />
     <PackageReference Include="WebEssentials.AspNetCore.StaticFilesWithCache" Version="1.0.3" />
     <PackageReference Include="WebMarkupMin.AspNetCore2" Version="2.8.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.17" />
   </ItemGroup>
 
 </Project>

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -3,6 +3,12 @@
     "Directory": "",
     "RemoveOldExtensions": true
   },
+  "Display": {
+    "HideSetupLink": false,
+    "HideUploadGuideLink": false,
+    "HideCreateExtensionLink": false,
+    "HideContributeLink": false
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/wwwroot/css/_variables.scss
+++ b/src/wwwroot/css/_variables.scss
@@ -1,4 +1,3 @@
 ﻿$light-backdrop: #d8d8d8;
 $dark-backdrop: #585858;
 $link-color: #1e6ab4;
-$footer-height: 185px;

--- a/src/wwwroot/css/site.scss
+++ b/src/wwwroot/css/site.scss
@@ -189,32 +189,40 @@ dt {
 footer {
     background: $dark-backdrop;
     color: white;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 
     a {
         color: inherit;
     }
 
     ul {
+        margin: 1em 0 0 0;
         list-style: none;
         padding: 0;
-    }
 
-    .container {
-        display: flex;
-        margin-bottom: 2em;
+        li {
+            display: inline-block;
 
-        > div:not(:first-child) {
-            margin-left: 2em;
+            &:not(:last-child) {
+                &::after {
+                    padding: 0 0.75em;
+                    content: '\00b7'; // &middot;
+                }
+            }
+        }
+
+        &:empty {
+            // Hide the element if none of the links inside it are displayed.
+            display: none;
         }
     }
 
-    h3 {
-        margin: 5px 0;
-    }
-
     #copyright {
-        text-align: center;
         font-size: .9em;
+        padding: 1em;
+        margin: 0;
     }
 }
 

--- a/src/wwwroot/css/site.scss
+++ b/src/wwwroot/css/site.scss
@@ -7,7 +7,7 @@
 
 html {
     position: relative;
-    min-height: 100%;
+    height: 100%;
     background: white;
     color: black;
 }
@@ -51,11 +51,15 @@ header {
 
 body {
     font: 16px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif;
-    margin: 0 0 $footer-height 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
 }
 
 main {
-    margin: 30px 0 ($footer-height + 25) 0;
+    margin: 30px 0 0 0;
+    flex: 1;
 }
 
 .container {
@@ -183,13 +187,6 @@ dt {
 }
 
 footer {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    display: block;
-    width: 100%;
-    height: $footer-height;
     background: $dark-backdrop;
     color: white;
 


### PR DESCRIPTION
Fixes #24.

There's a few changes here:
* Because all of the links in a group can be hidden, I found it was simpler to put all of the links into a single group instead of separating them into "How to" and "Contribute" sections.
* The page now uses a flex box layout rather than having a fixed height footer, because a fixed height leads to it taking up more space than necessary when some/all of the links are hidden.
* I've added the `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` package in the Debug configuration, as this made it easier to edit the layout without needing to restart the server.

And finally, I don't have a lot of experience with Razor pages, so hopefully I've used the correct technique to pass the options down to the layout page. 🤞 

Here's a screen capture of how it looks with different links hidden (I've edited the recording because you need to restart the server if you change the settings).

![footer](https://user-images.githubusercontent.com/10321525/126961690-6ce29f02-0e53-40b2-bcdd-9f242ffc879b.gif)
