### PR TITLE
Added authorization for uploading extensions.

### DIFF
--- a/src/Options/UploadOptions.cs
+++ b/src/Options/UploadOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace VsixGallery
+{
+	public class UploadOptions
+	{
+		public string SecretKey { get; set; }
+	}
+}

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -48,6 +48,7 @@ namespace VsixGallery
 
 			services.Configure<ExtensionsOptions>(Configuration.GetSection("Extensions"));
 			services.Configure<DisplayOptions>(Configuration.GetSection("Display"));
+			services.Configure<UploadOptions>(Configuration.GetSection("Upload"));
 
 			// HTML minification (https://github.com/Taritsyn/WebMarkupMin)
 			services

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -9,6 +9,9 @@
     "HideCreateExtensionLink": false,
     "HideContributeLink": false
   },
+  "Upload": {
+    "SecretKey": ""
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
Fixes #25.

Specify an `Upload.SecretKey` property in appsettings.json to require authorization, then specify that secret key using the `Bearer` scheme in the `Authorization` HTTP header. For example:

```json
{
   "Upload": {
        "SecretKey": "abcdefghij"
    }
}
```

```bash
curl --location --request POST 'https://localhost:5001/api/upload' \
--header 'Authorization: Bearer abcdefghij' \
--form '=@"/D://my-extension.vsix"'
```