### PR TITLE
Fixed crash when uploading extension without "repo" query parameter.

### DIFF
--- a/src/Code/VsixManifestParser.cs
+++ b/src/Code/VsixManifestParser.cs
@@ -64,10 +64,13 @@ namespace VsixGallery
 			{
 				return readmeUrl;
 			}
-			else
+
+			if (string.IsNullOrEmpty(repo))
 			{
-				return repo.Replace("https://github.com", "https://raw.githubusercontent.com").TrimEnd('/') + "/" + readmeUrl.TrimStart('/');
+				return "";
 			}
+
+			return repo.Replace("https://github.com", "https://raw.githubusercontent.com").TrimEnd('/') + "/" + readmeUrl.TrimStart('/');
 		}
 
 		private void AddExtensionList(Package package, string tempFolder)


### PR DESCRIPTION
If the `repo` query parameter wasn't specified, then it is `null`. When building the readme URL, a `NullReferenceExecption` would be thrown when trying to rewrite the GitHub URL.