### PR TITLE
Fixed output caching not working for custom extension directories

### DIFF
--- a/src/Code/ExtensionsFileProvider.cs
+++ b/src/Code/ExtensionsFileProvider.cs
@@ -11,9 +11,9 @@ namespace VsixGallery
 
 		private readonly IFileProvider _underlyingFileProvider;
 
-		public ExtensionsFileProvider(string extensionsDirectory)
+		public ExtensionsFileProvider(IFileProvider underlyingFileProvider)
 		{
-			_underlyingFileProvider = new PhysicalFileProvider(extensionsDirectory);
+			_underlyingFileProvider = underlyingFileProvider;
 		}
 
 		public IDirectoryContents GetDirectoryContents(string subpath)

--- a/src/Code/PackageHelper.cs
+++ b/src/Code/PackageHelper.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 
@@ -34,13 +35,18 @@ namespace VsixGallery
 			{
 				_extensionRoot = Path.Combine(env.WebRootPath, DefaultExtensionsPath);
 			}
+			else
+			{
+				IsCustomExtensionPath = true;
+			}
+
+			FileProvider = new PhysicalFileProvider(_extensionRoot);
 			_cache = GetAllPackages();
 		}
 
-		internal static bool IsCustomExtensionPath(ExtensionsOptions options)
-		{
-			return !string.IsNullOrEmpty(options. Directory);
-		}
+		public bool IsCustomExtensionPath { get; }
+
+		public IFileProvider FileProvider { get; }
 
 		public IReadOnlyList<Package> PackageCache => _cache;
 

--- a/src/Pages/Extension.cshtml.cs
+++ b/src/Pages/Extension.cshtml.cs
@@ -18,8 +18,6 @@ namespace VsixGallery.Pages
 		public void OnGet([FromRoute] string id)
 		{
 			Package = _helper.GetPackage(id);
-
-			string folder = $"wwwroot/extensions/{Package.ID}";
 		}
 	}
 }

--- a/src/Pages/Index.cshtml.cs
+++ b/src/Pages/Index.cshtml.cs
@@ -27,7 +27,7 @@ namespace VsixGallery.Pages
 
 		public void OnGet([FromQuery] int page = 1)
 		{
-			HttpContext.EnableOutputCaching(TimeSpan.FromDays(7), fileDependencies: "wwwroot/extensions", varyByParam: "page");
+			HttpContext.EnableOutputCaching(TimeSpan.FromDays(7), fileProvider: _helper.FileProvider, fileDependencies: "*", varyByParam: "page");
 			IEnumerable<Package> packages = _helper.PackageCache.Where(p => !p.Unlisted);
 
 			int skip = (page - 1) * _pageSize;

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -70,14 +70,14 @@ namespace VsixGallery
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
 		public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 		{
-			ExtensionsOptions extensionsOptions = app.ApplicationServices.GetRequiredService<IOptions<ExtensionsOptions>>().Value;
+			PackageHelper packageHelper = app.ApplicationServices.GetRequiredService<PackageHelper>();
 
 			// If extensions are being stored in a custom path, then we need to create a file provider
 			// that will act as though that custom path is under the "wwwroot/extensions" directory.
-			if (PackageHelper.IsCustomExtensionPath(extensionsOptions))
+			if (packageHelper.IsCustomExtensionPath)
 			{
 				env.WebRootFileProvider = new CompositeFileProvider(
-					new ExtensionsFileProvider(extensionsOptions.Directory),
+					new ExtensionsFileProvider(packageHelper.FileProvider),
 					env.WebRootFileProvider
 				);
 			}

--- a/src/VsixGallery.csproj
+++ b/src/VsixGallery.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="moment.net" Version="1.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
-    <PackageReference Include="WebEssentials.AspNetCore.OutputCaching" Version="1.0.28" />
+    <PackageReference Include="WebEssentials.AspNetCore.OutputCaching" Version="1.0.38" />
     <PackageReference Include="WebEssentials.AspNetCore.StaticFilesWithCache" Version="1.0.3" />
     <PackageReference Include="WebMarkupMin.AspNetCore2" Version="2.8.3" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #35.

This PR will need to be updated with the next version of  `WebEssentials.AspNetCore.OutputCaching` once https://github.com/madskristensen/WebEssentials.AspNetCore.OutputCaching/pull/21 is merged and published, but I thought I'd make a draft PR so you can see how that will be used.

Instead of using a file dependency of `wwwroot/extensions` for output caching, it uses the file provider for the extensions directory, and a file dependency of `*` which will watch for all changed under the extensions directory.