### PR TITLE
Added an option to disable license validation

### DIFF
--- a/src/Code/PackageHelper.cs
+++ b/src/Code/PackageHelper.cs
@@ -22,10 +22,12 @@ namespace VsixGallery
 		private readonly string _extensionRoot;
 		private readonly List<Package> _cache;
 		private readonly bool _canRemoveOldExtensions;
+		private readonly bool _canValidateLicenses;
 
 		public PackageHelper(IWebHostEnvironment env, IOptions<ExtensionsOptions> options)
 		{
 			_canRemoveOldExtensions = options.Value.RemoveOldExtensions;
+			_canValidateLicenses = options.Value.ValidateLicenses;
 			_extensionRoot = options.Value.Directory;
 
 			// Default to an "extensions" directory under the web root
@@ -127,7 +129,7 @@ namespace VsixGallery
 				errors.Add("Provide a clear description. Make sure to cover why it is great and what it does");
 			}
 
-			if (string.IsNullOrEmpty(package.License))
+			if (_canValidateLicenses && string.IsNullOrEmpty(package.License))
 			{
 				errors.Add("No license is specified in the .vsixmanifest");
 			}

--- a/src/Options/ExtensionsOptions.cs
+++ b/src/Options/ExtensionsOptions.cs
@@ -5,5 +5,7 @@
 		public string Directory { get; set; }
 
 		public bool RemoveOldExtensions { get; set; } = true;
+
+		public bool ValidateLicenses { get; set; } = true;
 	}
 }

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -1,7 +1,8 @@
 {
   "Extensions": {
     "Directory": "",
-    "RemoveOldExtensions": true
+    "RemoveOldExtensions": true,
+    "ValidateLicenses": true
   },
   "Display": {
     "SiteName": "Open VSIX Gallery",


### PR DESCRIPTION
When creating extensions in an organization, typically you don't add a license since they extensions are only available internally (at least that's how I do it). Doing that would cause a validation error to be shown on each extensions. I've added an option to disable the license check when validating an extension.