### PR TITLE
Avoid SSL certificate errors

### DIFF
--- a/src/Pages/feedguide.cshtml
+++ b/src/Pages/feedguide.cshtml
@@ -57,7 +57,7 @@
 
     <p>Click the <strong>Add</strong> button and fill in the name and URL fields.</p>
     <p><strong>Name</strong>: Give it a name you like</p>
-    <p><strong>URL</strong>: Could be the main feed <a href="/feed/" target="_self">https://vsixgallery.com/feed/</a></p>
+    <p><strong>URL</strong>: Could be the main feed <a href="/feed/" target="_self">https://www.vsixgallery.com/feed/</a></p>
     <p>And finally click the <strong>Apply</strong> button.</p>
 
     <p>


### PR DESCRIPTION
The current URL `https://vsixgallery.com/feed/` is causing SSL certificate errors.
Update the URL to `https://www.vsixgallery.com/feed/` to avoid SSL certificate errors.

If the SSL certificate itself needs to be fixed instead, please close this PR.