### PR TITLE
.NET10 support

### DIFF
--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -82,7 +82,6 @@ namespace VsixGallery
 
 			if (env.IsDevelopment())
 			{
-				app.UseBrowserLink();
 				app.UseDeveloperExceptionPage();
 			}
 			else

--- a/src/VsixGallery.csproj
+++ b/src/VsixGallery.csproj
@@ -11,7 +11,6 @@
     </PackageReference>
     <PackageReference Include="LigerShark.WebOptimizer.Sass" Version="3.0.91" />
     <PackageReference Include="Markdig" Version="0.37.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
     <PackageReference Include="moment.net" Version="1.3.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.0" />


### PR DESCRIPTION
.NET10 support: 
  - changed TargetFramework to net10.0
  - replaced `WebMarkupMin.AspNetCore8` with `WebMarkupMin.AspNetCoreLatest`
  - updated nugets from 8.0.x to 10.0.0
  - updated Newtonsoft.Json to 13.0.4